### PR TITLE
FIX: Compatibility with upcoming core changes

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.7.0.beta5: 1bb4ea40447dd7df40a822194c5deaa7f2e59b44

--- a/javascripts/discourse/initializers/dice-setup.js
+++ b/javascripts/discourse/initializers/dice-setup.js
@@ -3,8 +3,8 @@ import { getRegister } from "discourse-common/lib/get-owner";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import WidgetGlue from "discourse/widgets/glue";
 
-import MersenneTwister from "discourse/lib/mersenne-twister";
-import murmurhash3 from "discourse/lib/murmurhash3";
+import MersenneTwister from "../lib/mersenne-twister";
+import murmurhash3 from "../lib/murmurhash3";
 
 const MURMUR_HASH_SEED = 843031067;
 


### PR DESCRIPTION
Should be merged after https://github.com/discourse/discourse/commit/2b9ab3a0d91d1350188dd554764dbb4ce9837edd is un-reverted.